### PR TITLE
Create always thte ZIP file

### DIFF
--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -47,5 +47,4 @@ def createZIP(original_folder_path, zip_file_path, new_folder_name):
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_fw_files)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", copy_fw_files)
 # Single action/command per 1 target
-env.AddPostAction("checkprogsize", createCommunityZipFile)
-#env.AddCustomTarget("create_community_zip", None, createCommunityZipFile)
+env.AddCustomTarget("create_community_zip", None, createCommunityZipFile)

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -25,8 +25,7 @@ def copy_fw_files (source, target, env):
     if fw_file_name[-3:] == "bin":
         fw_file_name=fw_file_name[0:-3] + "uf2"
 
-    shutil.copy(fw_file_name, custom_device_folder + "/Community/firmware")
-
+def createCommunityZipFile(source, target, env):
     original_folder_path = custom_device_folder + "/Community"
     zip_file_path = './zip_files/' + community_project + '_' + firmware_version + '.zip'
     new_folder_in_zip = community_project
@@ -47,3 +46,6 @@ def createZIP(original_folder_path, zip_file_path, new_folder_name):
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_fw_files)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", copy_fw_files)
+# Single action/command per 1 target
+env.AddPostAction("checkprogsize", createCommunityZipFile)
+#env.AddCustomTarget("create_community_zip", None, createCommunityZipFile)

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ extra_configs = ./**/*platformio.ini
 
 ; Common build settings across all devices
 [env]
+targets = create_community_zip
 lib_deps = 
 	waspinator/AccelStepper @ 1.61
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4


### PR DESCRIPTION
## Description of changes

The Zip file is only created if the sources/platfomio.ini has changed. In case the content of the community folder changes the hex/uf2 file doesn't change and the post action `copy_fw_files` gets not executed.

The action `checkprogsize` is always executed, so building the community zip file will be called from this action.