### PR TITLE
Better naming for zip file on PR

### DIFF
--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -14,6 +14,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          prefix: "Firmware for this pull request:"
-          format: "[Firmware.zip]({url})"
+          prefix: "Community folder for this pull request:"
+          format: "[Community.zip]({url})"
           addTo: pull


### PR DESCRIPTION
## Description of changes

ZIP file on PR's are named `Firmware.zip`.
This is changed to `Community.zip' like on release.
