### PR TITLE
Copy always the zip file

### DIFF
--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -27,6 +27,7 @@ def copy_fw_files (source, target, env):
 
     shutil.copy(fw_file_name, custom_device_folder + "/Community/firmware")
 
+def createCommunityZipFile(source, target, env):
     original_folder_path = custom_device_folder + "/Community"
     zip_file_path = './zip_files/' + community_project + '_' + firmware_version + '.zip'
     new_folder_in_zip = community_project
@@ -47,3 +48,4 @@ def createZIP(original_folder_path, zip_file_path, new_folder_name):
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_fw_files)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", copy_fw_files)
+env.AddPostAction("checkprogsize", createCommunityZipFile)

--- a/copy_fw_files.py
+++ b/copy_fw_files.py
@@ -49,3 +49,4 @@ def createZIP(original_folder_path, zip_file_path, new_folder_name):
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.hex", copy_fw_files)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", copy_fw_files)
 env.AddPostAction("checkprogsize", createCommunityZipFile)
+#env.AddCustomTarget("create_community_zip", None, createCommunityZipFile)

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,6 @@ extra_configs = ./**/*platformio.ini
 
 ; Common build settings across all devices
 [env]
-;targets = create_community_zip
 lib_deps = 
 	waspinator/AccelStepper @ 1.61
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ extra_configs = ./**/*platformio.ini
 
 ; Common build settings across all devices
 [env]
+;targets = create_community_zip
 lib_deps = 
 	waspinator/AccelStepper @ 1.61
 	https://github.com/MobiFlight/LiquidCrystal_I2C#v1.1.4


### PR DESCRIPTION
## Description of changes

The zip files are not generated if nothing needs to be build.
This additional action will always generate the ZIP file, even if only files in the community folder has changed.
